### PR TITLE
Fix code scanning alert no. 10: Useless regular-expression character escape

### DIFF
--- a/mode/wast/wast.js
+++ b/mode/wast/wast.js
@@ -68,7 +68,7 @@ var kKeywords = [
     "i64\\.reinterpret_f64",
     // Atomics.
     "memory(\\.((atomic\\.(notify|wait(32|64)))|grow|size))?",
-    "i64\.atomic\\.(load32_u|store32|rmw32\\.(a[dn]d|sub|x?or|(cmp)?xchg)_u)",
+    "i64.atomic\\.(load32_u|store32|rmw32\\.(a[dn]d|sub|x?or|(cmp)?xchg)_u)",
     "i(32|64)\\.atomic\\.(load((8|16)_u)?|store(8|16)?|rmw(\\.(a[dn]d|sub|x?or|(cmp)?xchg)|(8|16)\\.(a[dn]d|sub|x?or|(cmp)?xchg)_u))",
     // SIMD.
     "v128\\.load(8x8|16x4|32x2)_[su]",


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/codemirror5/security/code-scanning/10](https://github.com/cooljeanius/codemirror5/security/code-scanning/10)

To fix the problem, we need to remove the unnecessary escape sequence `\.` in the regular expression. Specifically, we should replace `i64\.atomic\.` with `i64.atomic.` on line 71. This change will ensure that the regular expression is correctly interpreted and matches the intended patterns without any superfluous escape sequences.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
