### PR TITLE
Fix code scanning alert no. 9: Useless regular-expression character escape

### DIFF
--- a/mode/troff/troff.js
+++ b/mode/troff/troff.js
@@ -36,7 +36,7 @@ CodeMirror.defineMode('troff', function() {
         stream.eatWhile(/[\d-]/);
         return 'string';
       }
-      if (stream.match('\(') || stream.match('*\(')) {
+      if (stream.match('(') || stream.match('*(')) {
         stream.eatWhile(/[\w-]/);
         return 'string';
       }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/codemirror5/security/code-scanning/9](https://github.com/cooljeanius/codemirror5/security/code-scanning/9)

To fix the problem, we need to remove the unnecessary escape sequence in the regular expression. Specifically, we should replace `\(` with `(` in the `stream.match` method call. This change will not affect the functionality of the code but will make it clearer and more maintainable.

- **How to fix the problem:** Remove the unnecessary backslash in the regular expression.
- **Detailed description:** In the file `mode/troff/troff.js`, on line 39, replace `\(` with `(`.
- **Specific changes:** Edit line 39 to remove the unnecessary escape sequence.
- **Needed:** No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
