### PR TITLE
Fix code scanning alert no. 7: Useless regular-expression character escape

### DIFF
--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -33,7 +33,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
     "\\u00D7", "\\u2208", "\\u2209", "\\u220B", "\\u220C", "\\u2218",
     "\\u221A", "\\u221B", "\\u2229", "\\u222A", "\\u2260", "\\u2264",
     "\\u2265", "\\u2286", "\\u2288", "\\u228A", "\\u22C5",
-    "\\b(in|isa)\\b(?!\.?\\()"
+    "\\b(in|isa)\\b(?!\\.?\\()"
   ], "");
   var delimiters = parserConf.delimiters || /^[;,()[\]{}]/;
   var identifiers = parserConf.identifiers ||


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/codemirror5/security/code-scanning/7](https://github.com/cooljeanius/codemirror5/security/code-scanning/7)

To fix the problem, we need to remove the unnecessary escape sequence `\.` and replace it with the correct sequence. In this case, since `.` is intended to be a literal dot, we should use `\\.` to ensure it is treated as a literal dot in the regular expression.

- **General Fix:** Ensure that the right amount of backslashes is used when escaping characters in strings, template literals, and regular expressions.
- **Detailed Fix:** Replace the escape sequence `\.` with `\\.` on line 36 to ensure it is treated as a literal dot in the regular expression.
- **Specific Changes:** Modify the regular expression on line 36 in the file `mode/julia/julia.js`.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
