### PR TITLE
Fix code scanning alert no. 19: Inefficient regular expression

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -534,7 +534,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return type + tokenTypes.linkInline;
     }
 
-    if (ch === '<' && stream.match(/^[^\s>]+@[^\\s>]+(?:\\.[^\\s>]+)*>/, false)) {
+    if (ch === '<' && stream.match(/^[^\s>]+@[^\s>]+(?:\.[^\s>]+)*>/, false)) {
       state.f = state.inline = linkInline;
       if (modeCfg.highlightFormatting) state.formatting = "link";
       var type = getType(state);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/codemirror5/security/code-scanning/19](https://github.com/cooljeanius/codemirror5/security/code-scanning/19)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace the ambiguous `[^>]+` with a more precise pattern that avoids nested quantifiers. In this case, we can use a negated character class that excludes both whitespace and the `>` character, which will prevent the backtracking issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
