### PR TITLE
Fix code scanning alert no. 13: Overly permissive regular expression range

### DIFF
--- a/test/mode_test.js
+++ b/test/mode_test.js
@@ -28,7 +28,7 @@
     }
   }
 
-  var styleName = /[\w&-_]+/g;
+  var styleName = /[\w&-]+/g;
   function parseTokens(strs) {
     var tokens = [], plain = "";
     for (var i = 0; i < strs.length; ++i) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/codemirror5/security/code-scanning/13](https://github.com/cooljeanius/codemirror5/security/code-scanning/13)

To fix the problem, we need to make the regular expression more precise by removing the ambiguous range `-_` and explicitly listing the characters we want to match. Since `\w` already includes alphanumeric characters and underscores, we only need to add the hyphen and ampersand explicitly.

- Replace the regular expression `/[\w&-_]+/g` with `/[\w&-]+/g` to remove the ambiguous range.
- This change should be made on line 31 of the file `test/mode_test.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
