### PR TITLE
Cherry-pick commits from upstream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -697,6 +697,7 @@ Nils Knappmeier
 Nina Pypchenko
 Nisarg Jhaveri
 nlwillia
+noor.masarwa
 noragrossman
 Norman Rzepka
 Nouzbe

--- a/AUTHORS
+++ b/AUTHORS
@@ -978,6 +978,7 @@ Yuvi Panda
 Yvonnick Esnault
 Zac Anger
 Zachary Dremann
+Zaid Daba'een
 ZeeshanNoor
 Zeno Rocha
 Zhang Hao

--- a/AUTHORS
+++ b/AUTHORS
@@ -290,6 +290,7 @@ Filip Stollár
 Filype Pereira
 finalfantasia
 flack
+flofriday
 Florian Felten
 Fons van der Plas
 Forbes Lindesay
@@ -356,6 +357,7 @@ Hendrik Erz
 Hendrik Wallbaum
 Henrik Haugbølle
 Herculano Campos
+Hicham Omari
 hidaiy
 Hiroyuki Makino
 hitsthings
@@ -466,6 +468,7 @@ Joo
 Joost-Wim Boekesteijn
 José dBruxelles
 Joseph D. Purcell
+Joseph Olstad
 Joseph Pecoraro
 Josh Barnes
 Josh Cohen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.65.19 (2025-03-20)
+
+### Bug fixes
+
+[gherkin mode](https://codemirror.net/5/mode/gherkin/index.html): Add support for Rule Example keywords
+
+[pascal mode](https://codemirror.net/5/mode/pascal/index.html) Make keywords case-insensitive
+
+[sql mode](https://codemirror.net/5/mode/sql/) Support quoted identifier for PostgreSQL
+
 ## 5.65.18 (2024-09-20)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.65.20 (2025-08-10)
+
+### Bug fixes
+
+[show-hint addon](https://codemirror.net/5/doc/manual.html#addon_show-hint): Fix a positioning issue when the tooltip is at the bottom of the screen.
+
+[gas mode](https://codemirror.net/5/mode/gas/index.html): Properly define the MIME type the mode's demo page mentions.
+
 ## 5.65.19 (2025-03-20)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.65.21 (2026-02-07)
+
+### Bug fixes
+
+Better handle configuration objects with a null prototype.
+
+[kotlin mode](https://codemirror.net/5/mode/clike/): Fix tokenizing of unsigned long literals.
+
 ## 5.65.20 (2025-08-10)
 
 ### Bug fixes

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -290,7 +290,7 @@
       var height = box.bottom - box.top, spaceAbove = box.top - (pos.bottom - pos.top) - 2
       if (winH - box.top < spaceAbove) { // More room at the top
         if (height > spaceAbove) hints.style.height = (height = spaceAbove) + "px";
-        hints.style.top = ((top = pos.top - height) + offsetTop) + "px";
+        hints.style.top = ((top = pos.top - height) - offsetTop) + "px";
         below = false;
       } else {
         hints.style.height = (winH - box.top - 2) + "px";

--- a/demo/theme.html
+++ b/demo/theme.html
@@ -183,9 +183,10 @@ function findSequence(goal) {
   function selectTheme() {
     var theme = input.options[input.selectedIndex].textContent;
     editor.setOption("theme", theme);
-    location.hash = "#" + theme;
+    location.hash = "#" + encodeURIComponent(theme);
   }
-  var choice = (location.hash && location.hash.slice(1)) ||
+  var choice = (location.hash &&
+                decodeURIComponent(location.hash.slice(1))) ||
                (document.location.search &&
                 decodeURIComponent(document.location.search.slice(1)));
   if (choice) {
@@ -193,7 +194,7 @@ function findSequence(goal) {
     editor.setOption("theme", choice);
   }
   CodeMirror.on(window, "hashchange", function() {
-    var theme = location.hash.slice(1);
+    var theme = decodeURIComponent(location.hash.slice(1));
     if (theme) { input.value = theme; selectTheme(); }
   });
 </script>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -70,7 +70,7 @@
 <section class=first id=overview>
     <h2 style="position: relative">
       User manual and reference guide
-      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.20</span>
+      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.21</span>
     </h2>
 
     <p>CodeMirror is a code-editor component that can be embedded in

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -70,7 +70,7 @@
 <section class=first id=overview>
     <h2 style="position: relative">
       User manual and reference guide
-      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.18</span>
+      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.19</span>
     </h2>
 
     <p>CodeMirror is a code-editor component that can be embedded in

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -70,7 +70,7 @@
 <section class=first id=overview>
     <h2 style="position: relative">
       User manual and reference guide
-      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.19</span>
+      <span style="color: #888; font-size: 1rem; position: absolute; right: 0; bottom: 0">version 5.65.20</span>
     </h2>
 
     <p>CodeMirror is a code-editor component that can be embedded in

--- a/doc/releases.html
+++ b/doc/releases.html
@@ -34,7 +34,12 @@
 
   <h2>Version 5.x</h2>
 
-  <p class="rel">10-08-2025: <a href="https://codemirror.net/5/codemirror-5.65.20.zip">Version 5.65.20</a>:</p>
+  <p class="rel">07-02-2026: <a href="https://codemirror.net/5/codemirror-5.65.21.zip">Version 5.65.21</a>:</p>
+
+  <ul class="rel-note">
+    <li>Better handle configuration objects with a null prototype.
+    <li><a href="https://codemirror.net/5/mode/clike/">kotlin mode</a>: Fix tokenizing of unsigned long literals.
+  </ul>
 
   <ul class="rel-note">
     <li><a href="https://codemirror.net/5/doc/manual.html#addon_show-hint">show-hint addon</a>: Fix a positioning issue when the tooltip is at the bottom of the screen.

--- a/doc/releases.html
+++ b/doc/releases.html
@@ -34,6 +34,13 @@
 
   <h2>Version 5.x</h2>
 
+  <p class="rel">10-08-2025: <a href="https://codemirror.net/5/codemirror-5.65.20.zip">Version 5.65.20</a>:</p>
+
+  <ul class="rel-note">
+    <li><a href="https://codemirror.net/5/doc/manual.html#addon_show-hint">show-hint addon</a>: Fix a positioning issue when the tooltip is at the bottom of the screen.
+    <li><a href="https://codemirror.net/5/mode/gas/index.html">gas mode</a>: Properly define the MIME type the mode's demo page mentions.
+  </ul>
+
   <p class="rel">20-03-2025: <a href="https://codemirror.net/5/codemirror-5.65.19.zip">Version 5.65.19</a>:</p>
 
   <ul class="rel-note">

--- a/doc/releases.html
+++ b/doc/releases.html
@@ -34,6 +34,14 @@
 
   <h2>Version 5.x</h2>
 
+  <p class="rel">20-03-2025: <a href="https://codemirror.net/5/codemirror-5.65.19.zip">Version 5.65.19</a>:</p>
+
+  <ul class="rel-note">
+    <li><a href="https://codemirror.net/5/mode/gherkin/index.html">gherkin mode</a>: Add support for Rule Example keywords</li>
+    <li><a href="https://codemirror.net/5/mode/pascal/index.html">pascal mode</a> Make keywords case-insensitive</li>
+    <li><a href="https://codemirror.net/5/mode/sql/">sql mode</a> Support quoted identifier for PostgreSQL</li>
+  </ul>
+
   <p class="rel">20-09-2024: <a href="https://codemirror.net/5/codemirror-5.65.18.zip">Version 5.65.18</a>:</p>
 
   <ul class="rel-note">

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     });
 
   <div class=actions>
-    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.20</a>.<br>
+    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.21</a>.<br>
     You can see the <a href="https://github.com/codemirror/codemirror5" title="GitHub repository">code</a>,<br>
     read the <a href="doc/releases.html">release notes</a>,<br>
     or study the <a href="doc/manual.html">user manual</a>.

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     });
 
   <div class=actions>
-    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.19</a>.<br>
+    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.20</a>.<br>
     You can see the <a href="https://github.com/codemirror/codemirror5" title="GitHub repository">code</a>,<br>
     read the <a href="doc/releases.html">release notes</a>,<br>
     or study the <a href="doc/manual.html">user manual</a>.

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     });
 
   <div class=actions>
-    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.18</a>.<br>
+    Get the current version: <a href="https://codemirror.net/5/codemirror.zip">5.65.19</a>.<br>
     You can see the <a href="https://github.com/codemirror/codemirror5" title="GitHub repository">code</a>,<br>
     read the <a href="doc/releases.html">release notes</a>,<br>
     or study the <a href="doc/manual.html">user manual</a>.

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -680,7 +680,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     intendSwitch: false,
     indentStatements: false,
     multiLineStrings: true,
-    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(ul?|l|f)?/i,
     blockKeywords: words("catch class do else finally for if where try while enum"),
     defKeywords: words("class val var object interface fun"),
     atoms: words("true false null this"),

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -677,7 +677,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       "ByteArray Char CharArray DeprecationLevel DoubleArray Enum FloatArray Function Int IntArray Lazy " +
       "LazyThreadSafetyMode LongArray Nothing ShortArray Unit"
     ),
-    intendSwitch: false,
+    indentSwitch: false,
     indentStatements: false,
     multiLineStrings: true,
     number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+(\.\d+)?|\.\d+)(?:e[-+]?[\d_]+)?)(ul?|l|f)?/i,

--- a/mode/gas/gas.js
+++ b/mode/gas/gas.js
@@ -350,4 +350,6 @@ CodeMirror.defineMode("gas", function(_config, parserConfig) {
   };
 });
 
+CodeMirror.defineMIME("text/x-gas", "gas");
+
 });

--- a/mode/pascal/pascal.js
+++ b/mode/pascal/pascal.js
@@ -72,7 +72,7 @@ CodeMirror.defineMode("pascal", function() {
       return "operator";
     }
     stream.eatWhile(/[\w\$_]/);
-    var cur = stream.current();
+    var cur = stream.current().toLowerCase();
     if (keywords.propertyIsEnumerable(cur)) return "keyword";
     if (atoms.propertyIsEnumerable(cur)) return "atom";
     return "variable";

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -421,6 +421,10 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     atoms: set("false true null unknown"),
     operatorChars: /^[*\/+\-%<>!=&|^\/#@?~]/,
     backslashStringEscapes: false,
+    identifierQuote: "\"", // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    hooks: {
+      "\"":   hookIdentifierDoublequote
+    },
     dateSQL: set("date time timestamp"),
     support: set("decimallessFloat zerolessFloat binaryNumber hexNumber nCharCast charsetCast escapeConstant")
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror",
-  "version": "5.65.19",
+  "version": "5.65.20",
   "main": "lib/codemirror.js",
   "style": "lib/codemirror.css",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror",
-  "version": "5.65.20",
+  "version": "5.65.21",
   "main": "lib/codemirror.js",
   "style": "lib/codemirror.css",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror",
-  "version": "5.65.18",
+  "version": "5.65.19",
   "main": "lib/codemirror.js",
   "style": "lib/codemirror.css",
   "author": {

--- a/src/display/Display.js
+++ b/src/display/Display.js
@@ -49,7 +49,7 @@ export function Display(place, doc, input, options) {
   // The element in which the editor lives.
   d.wrapper = elt("div", [d.scrollbarFiller, d.gutterFiller, d.scroller], "CodeMirror")
   // See #6982. FIXME remove when this has been fixed for a while in Chrome
-  if (chrome && chrome_version >= 105) d.wrapper.style.clipPath = "inset(0px)"
+  if (chrome && chrome_version === 105) d.wrapper.style.clipPath = "inset(0px)"
 
   // This attribute is respected by automatic translation systems such as Google Translate,
   // and may also be respected by tools used by human translators.

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -66,4 +66,4 @@ import { addLegacyProps } from "./legacy.js"
 
 addLegacyProps(CodeMirror)
 
-CodeMirror.version = "5.65.18"
+CodeMirror.version = "5.65.19"

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -66,4 +66,4 @@ import { addLegacyProps } from "./legacy.js"
 
 addLegacyProps(CodeMirror)
 
-CodeMirror.version = "5.65.19"
+CodeMirror.version = "5.65.20"

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -66,4 +66,4 @@ import { addLegacyProps } from "./legacy.js"
 
 addLegacyProps(CodeMirror)
 
-CodeMirror.version = "5.65.20"
+CodeMirror.version = "5.65.21"

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -6,7 +6,7 @@ export function bind(f) {
 export function copyObj(obj, target, overwrite) {
   if (!target) target = {}
   for (let prop in obj)
-    if (obj.hasOwnProperty(prop) && (overwrite !== false || !target.hasOwnProperty(prop)))
+    if (Object.prototype.hasOwnProperty.call(obj, prop) && (overwrite !== false || !Object.prototype.hasOwnProperty.call(target, prop)))
       target[prop] = obj[prop]
   return target
 }


### PR DESCRIPTION
This brings master up-to-date with (approximately) the 5.65.21 upstream release